### PR TITLE
parse updates to lastpass

### DIFF
--- a/example/LastPass/Program.cs
+++ b/example/LastPass/Program.cs
@@ -77,7 +77,12 @@ namespace PasswordManagerAccess.Example.LastPass
                                        new ClientInfo(Platform.Desktop,
                                                       config["client-id"],
                                                       config["client-description"]),
-                                       new TextUi());
+                                       new TextUi(),
+                                       new ParserOptions
+                                       {
+                                           // Set to true to parse "server" secure notes
+                                           ParseSecureNotesToAccount = false,
+                                       });
 
                 // Dump all the accounts
                 for (var i = 0; i < vault.Accounts.Length; ++i)
@@ -89,14 +94,20 @@ namespace PasswordManagerAccess.Example.LastPass
                                       "  username: {3}\n" +
                                       "  password: {4}\n" +
                                       "       url: {5}\n" +
-                                      "      path: {6}\n",
+                                      "      path: {6}\n" +
+                                      "     notes: {7}\n" +
+                                      "  favorite: {8}\n" +
+                                      "    shared: {9}\n",
                                       i + 1,
                                       account.Id,
                                       account.Name,
                                       account.Username,
                                       account.Password,
                                       account.Url,
-                                      account.Path);
+                                      account.Path,
+                                      account.Notes,
+                                      account.IsFavorite,
+                                      account.IsShared);
                 }
             }
             catch (BaseException e)

--- a/example/LastPass/Program.cs
+++ b/example/LastPass/Program.cs
@@ -75,7 +75,7 @@ namespace PasswordManagerAccess.Example.LastPass
                 var vault = Vault.Open(config["username"],
                                        config["password"],
                                        new ClientInfo(Platform.Desktop,
-                                                      config["device-id"],
+                                                      config["client-id"],
                                                       config["client-description"]),
                                        new TextUi());
 

--- a/src/LastPass/Account.cs
+++ b/src/LastPass/Account.cs
@@ -11,8 +11,10 @@ namespace PasswordManagerAccess.LastPass
         public readonly string Password;
         public readonly string Url;
         public readonly string Path;
+        public readonly string Notes;
+        public readonly string Favorite;
 
-        public Account(string id, string name, string username, string password, string url, string path)
+        public Account(string id, string name, string username, string password, string url, string path, string notes, string favorite)
         {
             Id = id;
             Name = name;
@@ -20,6 +22,8 @@ namespace PasswordManagerAccess.LastPass
             Password = password;
             Url = url;
             Path = path;
+            Notes = notes;
+            Favorite= favorite;
         }
    }
 }

--- a/src/LastPass/Account.cs
+++ b/src/LastPass/Account.cs
@@ -13,8 +13,10 @@ namespace PasswordManagerAccess.LastPass
         public readonly string Path;
         public readonly string Notes;
         public readonly string Favorite;
+        public readonly bool Shared;
 
-        public Account(string id, string name, string username, string password, string url, string path, string notes, string favorite)
+        public Account(string id, string name, string username, string password, string url, string path,
+            string notes, string favorite, bool shared)
         {
             Id = id;
             Name = name;
@@ -24,6 +26,7 @@ namespace PasswordManagerAccess.LastPass
             Path = path;
             Notes = notes;
             Favorite= favorite;
+            Shared = shared;
         }
    }
 }

--- a/src/LastPass/Account.cs
+++ b/src/LastPass/Account.cs
@@ -12,11 +12,18 @@ namespace PasswordManagerAccess.LastPass
         public readonly string Url;
         public readonly string Path;
         public readonly string Notes;
-        public readonly string Favorite;
-        public readonly bool Shared;
+        public readonly bool IsFavorite;
+        public readonly bool IsShared;
 
-        public Account(string id, string name, string username, string password, string url, string path,
-            string notes, string favorite, bool shared)
+        public Account(string id,
+                       string name,
+                       string username,
+                       string password,
+                       string url,
+                       string path,
+                       string notes,
+                       bool isFavorite,
+                       bool isShared)
         {
             Id = id;
             Name = name;
@@ -25,8 +32,8 @@ namespace PasswordManagerAccess.LastPass
             Url = url;
             Path = path;
             Notes = notes;
-            Favorite= favorite;
-            Shared = shared;
+            IsFavorite = isFavorite;
+            IsShared = isShared;
         }
-   }
+    }
 }

--- a/src/LastPass/Parser.cs
+++ b/src/LastPass/Parser.cs
@@ -28,7 +28,7 @@ namespace PasswordManagerAccess.LastPass
         //
         // TODO: Add a test for the folder case!
         // TODO: Add a test case that covers secure note account!
-        public static Account Parse_ACCT(Chunk chunk, byte[] encryptionKey, SharedFolder folder = null)
+        public static Account Parse_ACCT(Chunk chunk, byte[] encryptionKey, SharedFolder folder, ParserOptions options)
         {
             return chunk.Payload.Open(reader =>
             {
@@ -54,7 +54,7 @@ namespace PasswordManagerAccess.LastPass
                 var secureNoteMarker = ReadItem(reader).ToUtf8();
 
                 // Parse secure note
-                if (ParserOptions.ParseSecureNotesToAccount && secureNoteMarker == "1")
+                if (options.ParseSecureNotesToAccount && secureNoteMarker == "1")
                 {
                     var type = "";
                     ParseSecureNoteServer(notes, ref type, ref url, ref username, ref password);

--- a/src/LastPass/Parser.cs
+++ b/src/LastPass/Parser.cs
@@ -54,7 +54,7 @@ namespace PasswordManagerAccess.LastPass
                 var secureNoteMarker = ReadItem(reader).ToUtf8();
 
                 // Parse secure note
-                if (false && secureNoteMarker == "1")
+                if (ParserOptions.ParseSecureNotesToAccount && secureNoteMarker == "1")
                 {
                     var type = "";
                     ParseSecureNoteServer(notes, ref type, ref url, ref username, ref password);

--- a/src/LastPass/Parser.cs
+++ b/src/LastPass/Parser.cs
@@ -45,7 +45,7 @@ namespace PasswordManagerAccess.LastPass
                     return null;
 
                 var notes = Util.DecryptAes256Plain(ReadItem(reader), encryptionKey, placeholder);
-                SkipItem(reader);
+                var favorite = ReadItem(reader).ToUtf8();
                 SkipItem(reader);
                 var username = Util.DecryptAes256Plain(ReadItem(reader), encryptionKey, placeholder);
                 var password = Util.DecryptAes256Plain(ReadItem(reader), encryptionKey, placeholder);
@@ -54,7 +54,7 @@ namespace PasswordManagerAccess.LastPass
                 var secureNoteMarker = ReadItem(reader).ToUtf8();
 
                 // Parse secure note
-                if (secureNoteMarker == "1")
+                if (false && secureNoteMarker == "1")
                 {
                     var type = "";
                     ParseSecureNoteServer(notes, ref type, ref url, ref username, ref password);
@@ -67,7 +67,7 @@ namespace PasswordManagerAccess.LastPass
                 // Adjust the path to include the group and the shared folder, if any.
                 var path = MakeAccountPath(group, folder);
 
-                return new Account(id, name, username, password, url, path);
+                return new Account(id, name, username, password, url, path, notes, favorite);
             });
         }
 

--- a/src/LastPass/Parser.cs
+++ b/src/LastPass/Parser.cs
@@ -45,7 +45,7 @@ namespace PasswordManagerAccess.LastPass
                     return null;
 
                 var notes = Util.DecryptAes256Plain(ReadItem(reader), encryptionKey, placeholder);
-                var favorite = ReadItem(reader).ToUtf8();
+                var isFavorite = ReadItem(reader).ToUtf8() == "1";
                 SkipItem(reader);
                 var username = Util.DecryptAes256Plain(ReadItem(reader), encryptionKey, placeholder);
                 var password = Util.DecryptAes256Plain(ReadItem(reader), encryptionKey, placeholder);
@@ -67,7 +67,15 @@ namespace PasswordManagerAccess.LastPass
                 // Adjust the path to include the group and the shared folder, if any.
                 var path = MakeAccountPath(group, folder);
 
-                return new Account(id, name, username, password, url, path, notes, favorite, folder != null);
+                return new Account(id: id,
+                                   name: name,
+                                   username: username,
+                                   password: password,
+                                   url: url,
+                                   path: path,
+                                   notes: notes,
+                                   isFavorite: isFavorite,
+                                   isShared: folder != null);
             });
         }
 

--- a/src/LastPass/Parser.cs
+++ b/src/LastPass/Parser.cs
@@ -67,7 +67,7 @@ namespace PasswordManagerAccess.LastPass
                 // Adjust the path to include the group and the shared folder, if any.
                 var path = MakeAccountPath(group, folder);
 
-                return new Account(id, name, username, password, url, path, notes, favorite);
+                return new Account(id, name, username, password, url, path, notes, favorite, folder != null);
             });
         }
 

--- a/src/LastPass/ParserOptions.cs
+++ b/src/LastPass/ParserOptions.cs
@@ -1,7 +1,12 @@
 namespace PasswordManagerAccess.LastPass
 {
-    public static class ParserOptions
+    public class ParserOptions
     {
-        public static bool ParseSecureNotesToAccount = true;
+        public static ParserOptions Default { get; } = new ParserOptions();
+
+        // When is is enabled the library attempts to convert the secure notes that look like accounts into accounts.
+        // Other types of notes are discarded. If you want to have all the secure notes return in a form of accounts,
+        // set this to false.
+        public bool ParseSecureNotesToAccount { get; set; } = true;
     }
 }

--- a/src/LastPass/ParserOptions.cs
+++ b/src/LastPass/ParserOptions.cs
@@ -1,0 +1,7 @@
+namespace PasswordManagerAccess.LastPass
+{
+    public static class ParserOptions
+    {
+        public static bool ParseSecureNotesToAccount = true;
+    }
+}

--- a/src/LastPass/Vault.cs
+++ b/src/LastPass/Vault.cs
@@ -12,8 +12,13 @@ namespace PasswordManagerAccess.LastPass
 
         public static Vault Open(string username, string password, ClientInfo clientInfo, IUi ui)
         {
+            return Open(username, password, clientInfo, ui, ParserOptions.Default);
+        }
+
+        public static Vault Open(string username, string password, ClientInfo clientInfo, IUi ui, ParserOptions options)
+        {
             using var transport = new RestTransport();
-            return new Vault(Client.OpenVault(username, password, clientInfo, ui, transport));
+            return new Vault(Client.OpenVault(username, password, clientInfo, ui, transport, options));
         }
 
         public static string GenerateRandomClientId()

--- a/test/LastPass/AccountTest.cs
+++ b/test/LastPass/AccountTest.cs
@@ -17,8 +17,10 @@ namespace PasswordManagerAccess.Test.LastPass
             var password = "password";
             var url = "url";
             var path = "path/to/item";
+            var notes = "note";
+            var favorite = "1";
 
-            var account = new Account(id, name, username, password, url, path);
+            var account = new Account(id, name, username, password, url, path, notes, favorite);
 
             Assert.Equal(id, account.Id);
             Assert.Equal(name, account.Name);
@@ -26,6 +28,8 @@ namespace PasswordManagerAccess.Test.LastPass
             Assert.Equal(password, account.Password);
             Assert.Equal(url, account.Url);
             Assert.Equal(path, account.Path);
+            Assert.Equal(notes, account.Notes);
+            Assert.Equal(favorite, account.Favorite);
         }
     }
 }

--- a/test/LastPass/AccountTest.cs
+++ b/test/LastPass/AccountTest.cs
@@ -18,10 +18,18 @@ namespace PasswordManagerAccess.Test.LastPass
             var url = "url";
             var path = "path/to/item";
             var notes = "note";
-            var favorite = "1";
-            var shared = true;
+            var isFavorite = true;
+            var isShared = true;
 
-            var account = new Account(id, name, username, password, url, path, notes, favorite, shared);
+            var account = new Account(id: id,
+                                      name: name,
+                                      username: username,
+                                      password: password,
+                                      url: url,
+                                      path: path,
+                                      notes: notes,
+                                      isFavorite: isFavorite,
+                                      isShared: isShared);
 
             Assert.Equal(id, account.Id);
             Assert.Equal(name, account.Name);
@@ -30,8 +38,8 @@ namespace PasswordManagerAccess.Test.LastPass
             Assert.Equal(url, account.Url);
             Assert.Equal(path, account.Path);
             Assert.Equal(notes, account.Notes);
-            Assert.Equal(favorite, account.Favorite);
-            Assert.Equal(shared, account.Shared);
+            Assert.Equal(isFavorite, account.IsFavorite);
+            Assert.Equal(isShared, account.IsShared);
         }
     }
 }

--- a/test/LastPass/AccountTest.cs
+++ b/test/LastPass/AccountTest.cs
@@ -19,8 +19,9 @@ namespace PasswordManagerAccess.Test.LastPass
             var path = "path/to/item";
             var notes = "note";
             var favorite = "1";
+            var shared = true;
 
-            var account = new Account(id, name, username, password, url, path, notes, favorite);
+            var account = new Account(id, name, username, password, url, path, notes, favorite, shared);
 
             Assert.Equal(id, account.Id);
             Assert.Equal(name, account.Name);
@@ -30,6 +31,7 @@ namespace PasswordManagerAccess.Test.LastPass
             Assert.Equal(path, account.Path);
             Assert.Equal(notes, account.Notes);
             Assert.Equal(favorite, account.Favorite);
+            Assert.Equal(shared, account.Shared);
         }
     }
 }

--- a/test/LastPass/ClientTest.cs
+++ b/test/LastPass/ClientTest.cs
@@ -29,7 +29,7 @@ namespace PasswordManagerAccess.Test.LastPass
                     .ExpectUrl("/logout.php");
 
             // TODO: Decryption fails here because of the incorrect password
-            var accounts = Client.OpenVault(Username, Password, ClientInfo, null, flow);
+            var accounts = Client.OpenVault(Username, Password, ClientInfo, null, flow, ParserOptions.Default);
 
             Assert.NotEmpty(accounts);
         }
@@ -48,7 +48,7 @@ namespace PasswordManagerAccess.Test.LastPass
                     .ExpectUrl("/logout.php");
 
             // TODO: Decryption fails here because of the incorrect password
-            var accounts = Client.OpenVault(Username, Password, ClientInfo, null, flow);
+            var accounts = Client.OpenVault(Username, Password, ClientInfo, null, flow, ParserOptions.Default);
 
             Assert.NotEmpty(accounts);
         }
@@ -68,7 +68,7 @@ namespace PasswordManagerAccess.Test.LastPass
                     .ExpectUrl("/logout.php");
 
             // TODO: Decryption fails here because of the incorrect password
-            var accounts = Client.OpenVault(Username, Password, ClientInfo, OtpProvidingUi, flow);
+            var accounts = Client.OpenVault(Username, Password, ClientInfo, OtpProvidingUi, flow, ParserOptions.Default);
 
             Assert.NotEmpty(accounts);
         }
@@ -90,7 +90,12 @@ namespace PasswordManagerAccess.Test.LastPass
                     .ExpectUrl("/logout.php");
 
             // TODO: Decryption fails here because of the incorrect password
-            var accounts = Client.OpenVault(Username, Password, ClientInfo, OtpProvidingWithRememberMeUi, flow);
+            var accounts = Client.OpenVault(Username,
+                                            Password,
+                                            ClientInfo,
+                                            OtpProvidingWithRememberMeUi,
+                                            flow,
+                                            ParserOptions.Default);
 
             Assert.NotEmpty(accounts);
         }
@@ -115,7 +120,12 @@ namespace PasswordManagerAccess.Test.LastPass
                     .ExpectUrl("/logout.php");
 
             // TODO: Decryption fails here because of the incorrect password
-            var accounts = Client.OpenVault(Username, Password, ClientInfo, WaitingForOobUi, flow);
+            var accounts = Client.OpenVault(Username,
+                                            Password,
+                                            ClientInfo,
+                                            WaitingForOobUi,
+                                            flow,
+                                            ParserOptions.Default);
 
             Assert.NotEmpty(accounts);
         }
@@ -142,7 +152,12 @@ namespace PasswordManagerAccess.Test.LastPass
                     .ExpectUrl("/logout.php");
 
             // TODO: Decryption fails here because of the incorrect password
-            var accounts = Client.OpenVault(Username, Password, ClientInfo, WaitingForOobWithRememberMeUi, flow);
+            var accounts = Client.OpenVault(Username,
+                                            Password,
+                                            ClientInfo,
+                                            WaitingForOobWithRememberMeUi,
+                                            flow,
+                                            ParserOptions.Default);
 
             Assert.NotEmpty(accounts);
         }
@@ -158,7 +173,12 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post("");
 
             // TODO: Decryption fails here because of the incorrect password
-            var accounts = Client.OpenVault(Username.ToUpperInvariant(), Password, ClientInfo, null, flow);
+            var accounts = Client.OpenVault(Username.ToUpperInvariant(),
+                                            Password,
+                                            ClientInfo,
+                                            null,
+                                            flow,
+                                            ParserOptions.Default);
 
             Assert.NotEmpty(accounts);
         }
@@ -170,7 +190,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post("<response><error cause='unknownemail' /></response>");
 
             Exceptions.AssertThrowsBadCredentials(
-                () => Client.OpenVault(Username, Password, ClientInfo, null, flow),
+                () => Client.OpenVault(Username, Password, ClientInfo, null, flow, ParserOptions.Default),
                 "Invalid username");
         }
 
@@ -181,7 +201,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post("<response><error cause='unknownpassword' /></response>");
 
             Exceptions.AssertThrowsBadCredentials(
-                () => Client.OpenVault(Username, Password, ClientInfo, null, flow),
+                () => Client.OpenVault(Username, Password, ClientInfo, null, flow, ParserOptions.Default),
                 "Invalid password");
         }
 
@@ -192,7 +212,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post(OtpRequiredResponse);
 
             Exceptions.AssertThrowsCanceledMultiFactor(
-                () => Client.OpenVault(Username, Password, ClientInfo, CancelingUi, flow),
+                () => Client.OpenVault(Username, Password, ClientInfo, CancelingUi, flow, ParserOptions.Default),
                 "Second factor step is canceled by the user");
         }
 
@@ -204,7 +224,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post("<response><error cause='googleauthfailed' /></response>");
 
             Exceptions.AssertThrowsBadMultiFactor(
-                () => Client.OpenVault(Username, Password, ClientInfo, OtpProvidingUi, flow),
+                () => Client.OpenVault(Username, Password, ClientInfo, OtpProvidingUi, flow, ParserOptions.Default),
                 "Second factor code is incorrect");
         }
 
@@ -215,7 +235,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post(OobRequiredResponse);
 
             Exceptions.AssertThrowsCanceledMultiFactor(
-                () => Client.OpenVault(Username, Password, ClientInfo, CancelingUi, flow),
+                () => Client.OpenVault(Username, Password, ClientInfo, CancelingUi, flow, ParserOptions.Default),
                 "Out of band step is canceled by the user");
         }
 
@@ -227,7 +247,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post("<response><error cause='multifactorresponsefailed' /></response>");
 
             Exceptions.AssertThrowsBadMultiFactor(
-                () => Client.OpenVault(Username, Password, ClientInfo, WaitingForOobUi, flow),
+                () => Client.OpenVault(Username, Password, ClientInfo, WaitingForOobUi, flow, ParserOptions.Default),
                 "Out of band authentication failed");
         }
 
@@ -242,7 +262,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 .Post(response);
 
             Exceptions.AssertThrowsInternalError(
-                () => Client.OpenVault(Username, Password, ClientInfo, null, flow),
+                () => Client.OpenVault(Username, Password, ClientInfo, null, flow, ParserOptions.Default),
                 expected);
         }
 
@@ -810,7 +830,10 @@ namespace PasswordManagerAccess.Test.LastPass
         [Fact]
         public void ParseVault_returns_vault_with_correct_accounts()
         {
-            var accounts = Client.ParseVault(TestData.Blob, TestData.EncryptionKey, TestData.PrivateKey);
+            var accounts = Client.ParseVault(TestData.Blob,
+                                             TestData.EncryptionKey,
+                                             TestData.PrivateKey,
+                                             ParserOptions.Default);
 
             Assert.Equal(TestData.Accounts.Length, accounts.Length);
             for (var i = 0; i < accounts.Length; i++)
@@ -838,7 +861,8 @@ namespace PasswordManagerAccess.Test.LastPass
             Exceptions.AssertThrowsInternalError(
                 () => Client.ParseVault(TestData.Blob.Sub(0, TestData.Blob.Length - cut),
                                         TestData.EncryptionKey,
-                                        TestData.PrivateKey),
+                                        TestData.PrivateKey,
+                                        ParserOptions.Default),
                 "Blob is truncated or corrupted");
         }
 

--- a/test/LastPass/ParserTest.cs
+++ b/test/LastPass/ParserTest.cs
@@ -44,7 +44,7 @@ namespace PasswordManagerAccess.Test.LastPass
                 var accounts = Parser.ExtractChunks(reader).Where(i => i.Id == "ACCT").ToArray();
                 for (var i = 0; i < accounts.Length; ++i)
                 {
-                    var account = Parser.Parse_ACCT(accounts[i], TestData.EncryptionKey);
+                    var account = Parser.Parse_ACCT(accounts[i], TestData.EncryptionKey, null, ParserOptions.Default);
                     Assert.StartsWith(TestData.Accounts[i].Url, account.Url);
                 }
             });
@@ -53,8 +53,7 @@ namespace PasswordManagerAccess.Test.LastPass
         [Fact]
         public void ParseEncryptedPrivateKey_returns_private_key()
         {
-            var rsa = Parser.ParseEncryptedPrivateKey(TestData.EncryptedPrivateKey,
-                                                           TestData.EncryptionKey);
+            var rsa = Parser.ParseEncryptedPrivateKey(TestData.EncryptedPrivateKey, TestData.EncryptionKey);
 
             Assert.Equal(TestData.RsaD, rsa.D);
             Assert.Equal(TestData.RsaDP, rsa.DP);


### PR DESCRIPTION
Hey, thanks for this library. We are trying to use it to build some migration tools from other password managers into Bitwarden.

I am working with LastPass for now and noticed two issues:

1. Favorites and notes was missing from the Account object. I added those in. I also added an `Shared` boolean property that tells us in the LastPass account came from a shared folder or not.
2. UPDATE: I added a configuration option for this with a new static ParserOptions class.
   
    [Here ](https://github.com/detunized/password-manager-access/blob/master/src/LastPass/Parser.cs#L57-L65) you are trying to parse Accounts that are marked as a secure note back to an Account structure. And if it cannot be parsed that way (for example, a credit card of address), they are skipped. We need these to still be included for our importer. In my PR here, I just skip this logic by adding `false` to the condition, but obviously this is not ideal. Do you suggest any other way to handle this or turn this functionality off? Perhaps with some sort of static settings assignment, `ParseNotesToAccount = false` or someting?

3. Your LastPass example console app was not referencing the correct config.yaml property for `client-id`