### PR TITLE
add salesforce authenticator for lastpass

### DIFF
--- a/example/LastPass/Program.cs
+++ b/example/LastPass/Program.cs
@@ -40,6 +40,11 @@ namespace PasswordManagerAccess.Example.LastPass
                 return ApproveOutOfBand("Duo Security");
             }
 
+            public OobResult ApproveSalesforceAuth()
+            {
+                return ApproveOutOfBand("Salesforce Authenticator");
+            }
+
             //
             // Private
             //

--- a/src/LastPass/Client.cs
+++ b/src/LastPass/Client.cs
@@ -274,6 +274,7 @@ namespace PasswordManagerAccess.LastPass
             {
                 "lastpassauth" => ui.ApproveLastPassAuth(),
                 "duo" => ApproveDuo(username, parameters, ui, rest),
+                "salesforcehash" => ui.ApproveSalesforceAuth(),
                 _ => throw new UnsupportedFeatureException($"Out of band method '{method}' is not supported")
             };
         }

--- a/src/LastPass/Ui.cs
+++ b/src/LastPass/Ui.cs
@@ -27,6 +27,7 @@ namespace PasswordManagerAccess.LastPass.Ui
         //    OobResult.ContinueWithPasscode(passcode, rememberMe).
         OobResult ApproveLastPassAuth();
         OobResult ApproveDuo();
+        OobResult ApproveSalesforceAuth();
     }
 
     public class OtpResult

--- a/test/LastPass/ClientTest.cs
+++ b/test/LastPass/ClientTest.cs
@@ -587,6 +587,17 @@ namespace PasswordManagerAccess.Test.LastPass
         }
 
         [Fact]
+        public void ApproveOob_calls_Ui_ApproveSalesforceAuth()
+        {
+            var ui = new Mock<IUi>();
+            ui.Setup(x => x.ApproveSalesforceAuth()).Returns(OobResult.Cancel);
+
+            Client.ApproveOob(Username, SalesforceAuthOobParameters, ui.Object, null);
+
+            ui.VerifyAll();
+        }
+
+        [Fact]
         public void ApproveOob_calls_IDuoUi()
         {
             // TODO: See how to test this. Maybe Duo.Authenticate should be hidden behind an interface that we can mock.
@@ -896,6 +907,7 @@ namespace PasswordManagerAccess.Test.LastPass
             public OtpResult ProvideYubikeyPasscode() => _otp;
             public OobResult ApproveLastPassAuth() => _oob;
             public OobResult ApproveDuo() => _oob;
+            public OobResult ApproveSalesforceAuth() => _oob;
 
             public DuoChoice ChooseDuoFactor(DuoDevice[] devices)
             {
@@ -969,6 +981,11 @@ namespace PasswordManagerAccess.Test.LastPass
         private static readonly Dictionary<string, string> DuoOobParameters = new Dictionary<string, string>
         {
             ["outofbandtype"] = "duo"
+        };
+
+        private static readonly Dictionary<string, string> SalesforceAuthOobParameters = new Dictionary<string, string>
+        {
+            ["outofbandtype"] = "salesforcehash"
         };
 
         // OTP and OOB


### PR DESCRIPTION
LastPass supports Salesforce Authenticator as a 2FA method for their business customers.

This PR adds supports for Sales Authenticator as a OOB authenticator, similar to LastPass Authenticator. I have functional tested it with my LastPass Enterprise account and it seems to work fine.